### PR TITLE
Add session auth middleware, tests, and router hook

### DIFF
--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -5,12 +5,15 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/chi/v5/middleware"
+	chimw "github.com/go-chi/chi/v5/middleware"
+
+	"github.com/claude/blog/internal/middleware"
 )
 
 func NewRouter(db *sql.DB, staticDir string) http.Handler {
 	r := chi.NewRouter()
-	r.Use(middleware.Logger)
+	r.Use(chimw.Logger)
+	r.Use(middleware.AuthMiddleware(db))
 	r.Get("/", Home(db))
 	r.Handle("/static/*", http.StripPrefix("/static/", http.FileServer(http.Dir(staticDir))))
 	r.Handle("/favicon.ico", http.FileServer(http.Dir(staticDir)))

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,87 @@
+package middleware
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+
+	"github.com/claude/blog/internal/model"
+)
+
+const sessionCookieName = "session"
+
+// AuthMiddleware reads the session cookie and loads the matching user into the
+// request context. Visitors (no cookie or invalid token) get a nil user.
+func AuthMiddleware(db *sql.DB) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cookie, err := r.Cookie(sessionCookieName)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			user, err := model.SessionUser(db, cookie.Value)
+			if err != nil && !errors.Is(err, model.ErrSessionNotFound) {
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
+			}
+
+			if user != nil {
+				model.UpdateLastActive(db, user.ID) //nolint:errcheck
+				r = r.WithContext(model.WithUser(r.Context(), user))
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequireAuth rejects unauthenticated requests with 401.
+func RequireAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if model.UserFromContext(r.Context()) == nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// RequireRole rejects requests whose user does not have one of the allowed roles.
+// Returns 401 if not logged in at all, 403 if logged in with the wrong role.
+func RequireRole(roles ...string) func(http.Handler) http.Handler {
+	allowed := make(map[string]bool, len(roles))
+	for _, role := range roles {
+		allowed[role] = true
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user := model.UserFromContext(r.Context())
+			if user == nil {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			if !allowed[user.Role] {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequireVerified requires role verified, moderator, or curator.
+func RequireVerified(next http.Handler) http.Handler {
+	return RequireRole("verified", "moderator", "curator")(next)
+}
+
+// RequireModerator requires role moderator or curator.
+func RequireModerator(next http.Handler) http.Handler {
+	return RequireRole("moderator", "curator")(next)
+}
+
+// RequireCurator requires role curator.
+func RequireCurator(next http.Handler) http.Handler {
+	return RequireRole("curator")(next)
+}

--- a/tests/middleware_test.go
+++ b/tests/middleware_test.go
@@ -1,0 +1,264 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/claude/blog/internal/middleware"
+	"github.com/claude/blog/internal/model"
+)
+
+// okHandler is a trivial handler that writes 200.
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+func TestAuthMiddleware_NoCookie(t *testing.T) {
+	db := openTestDB(t)
+
+	handler := middleware.AuthMiddleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if model.UserFromContext(r.Context()) != nil {
+			t.Error("expected nil user for request without cookie")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestAuthMiddleware_ValidSession(t *testing.T) {
+	db := openTestDB(t)
+
+	u, err := model.CreateUser(db, "mw_alice", "mw_alice@example.com", "pass")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	token, err := model.CreateSession(db, u.ID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	handler := middleware.AuthMiddleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := model.UserFromContext(r.Context())
+		if got == nil {
+			t.Error("expected user in context, got nil")
+		} else if got.ID != u.ID {
+			t.Errorf("user ID: got %d, want %d", got.ID, u.ID)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: token})
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestAuthMiddleware_InvalidToken(t *testing.T) {
+	db := openTestDB(t)
+
+	handler := middleware.AuthMiddleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if model.UserFromContext(r.Context()) != nil {
+			t.Error("expected nil user for invalid token")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "bogus-token"})
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRequireAuth_NoUser(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	middleware.RequireAuth(okHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequireAuth_WithUser(t *testing.T) {
+	db := openTestDB(t)
+
+	u, err := model.CreateUser(db, "mw_bob", "mw_bob@example.com", "pass")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(model.WithUser(req.Context(), u))
+	rr := httptest.NewRecorder()
+	middleware.RequireAuth(okHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRequireRole_NoUser(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	middleware.RequireRole("curator")(okHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequireRole_WrongRole(t *testing.T) {
+	db := openTestDB(t)
+
+	u, err := model.CreateUser(db, "mw_carol", "mw_carol@example.com", "pass")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	// Default role is "unverified", not "curator".
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(model.WithUser(req.Context(), u))
+	rr := httptest.NewRecorder()
+	middleware.RequireRole("curator")(okHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}
+
+func TestRequireRole_CorrectRole(t *testing.T) {
+	db := openTestDB(t)
+
+	u, err := model.CreateUser(db, "mw_dave", "mw_dave@example.com", "pass")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := model.UpdateUserRole(db, u.ID, "curator"); err != nil {
+		t.Fatalf("UpdateUserRole: %v", err)
+	}
+	u.Role = "curator"
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(model.WithUser(req.Context(), u))
+	rr := httptest.NewRecorder()
+	middleware.RequireRole("curator")(okHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRequireVerified(t *testing.T) {
+	db := openTestDB(t)
+
+	cases := []struct {
+		role string
+		want int
+	}{
+		{"unverified", http.StatusForbidden},
+		{"verified", http.StatusOK},
+		{"moderator", http.StatusOK},
+		{"curator", http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.role, func(t *testing.T) {
+			u, err := model.CreateUser(db, "mw_v_"+tc.role, "mw_v_"+tc.role+"@example.com", "pass")
+			if err != nil {
+				t.Fatalf("CreateUser: %v", err)
+			}
+			u.Role = tc.role
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req = req.WithContext(model.WithUser(req.Context(), u))
+			rr := httptest.NewRecorder()
+			middleware.RequireVerified(okHandler).ServeHTTP(rr, req)
+
+			if rr.Code != tc.want {
+				t.Errorf("role %q: got %d, want %d", tc.role, rr.Code, tc.want)
+			}
+		})
+	}
+}
+
+func TestRequireModerator(t *testing.T) {
+	db := openTestDB(t)
+
+	cases := []struct {
+		role string
+		want int
+	}{
+		{"unverified", http.StatusForbidden},
+		{"verified", http.StatusForbidden},
+		{"moderator", http.StatusOK},
+		{"curator", http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.role, func(t *testing.T) {
+			u, err := model.CreateUser(db, "mw_m_"+tc.role, "mw_m_"+tc.role+"@example.com", "pass")
+			if err != nil {
+				t.Fatalf("CreateUser: %v", err)
+			}
+			u.Role = tc.role
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req = req.WithContext(model.WithUser(req.Context(), u))
+			rr := httptest.NewRecorder()
+			middleware.RequireModerator(okHandler).ServeHTTP(rr, req)
+
+			if rr.Code != tc.want {
+				t.Errorf("role %q: got %d, want %d", tc.role, rr.Code, tc.want)
+			}
+		})
+	}
+}
+
+func TestRequireCurator(t *testing.T) {
+	db := openTestDB(t)
+
+	cases := []struct {
+		role string
+		want int
+	}{
+		{"unverified", http.StatusForbidden},
+		{"verified", http.StatusForbidden},
+		{"moderator", http.StatusForbidden},
+		{"curator", http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.role, func(t *testing.T) {
+			u, err := model.CreateUser(db, "mw_c_"+tc.role, "mw_c_"+tc.role+"@example.com", "pass")
+			if err != nil {
+				t.Fatalf("CreateUser: %v", err)
+			}
+			u.Role = tc.role
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req = req.WithContext(model.WithUser(req.Context(), u))
+			rr := httptest.NewRecorder()
+			middleware.RequireCurator(okHandler).ServeHTTP(rr, req)
+
+			if rr.Code != tc.want {
+				t.Errorf("role %q: got %d, want %d", tc.role, rr.Code, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduce session-based authentication middleware (internal/middleware/auth.go) that loads a user from the session cookie into request context, updates last-active, and provides RequireAuth/RequireRole/RequireVerified/RequireModerator/RequireCurator guards. Wire the middleware into the router (internal/handler/router.go) and keep chi's Logger via an import alias. Add comprehensive tests (tests/middleware_test.go) covering cookie absence, valid/invalid sessions, and role-based access checks.