### PR TITLE
Add Markdown renderer with safe/unsafe modes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/yuin/goldmark v1.8.2 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	modernc.org/libc v1.70.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/render/markdown.go
+++ b/internal/render/markdown.go
@@ -1,0 +1,38 @@
+package render
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/renderer/html"
+)
+
+var mdSafe = goldmark.New(
+	goldmark.WithExtensions(extension.GFM),
+)
+
+var mdUnsafe = goldmark.New(
+	goldmark.WithExtensions(extension.GFM),
+	goldmark.WithRendererOptions(html.WithUnsafe()),
+)
+
+// RenderMarkdown converts Markdown to HTML with GFM extensions.
+// Raw HTML in the source is stripped to prevent XSS.
+func RenderMarkdown(src string) (string, error) {
+	var buf bytes.Buffer
+	if err := mdSafe.Convert([]byte(src), &buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// RenderMarkdownUnsafe converts Markdown to HTML with GFM extensions,
+// allowing raw HTML passthrough. Use only for trusted curator content.
+func RenderMarkdownUnsafe(src string) (string, error) {
+	var buf bytes.Buffer
+	if err := mdUnsafe.Convert([]byte(src), &buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/tests/markdown_test.go
+++ b/tests/markdown_test.go
@@ -1,0 +1,70 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/claude/blog/internal/render"
+)
+
+func TestRenderMarkdown_Paragraph(t *testing.T) {
+	out, err := render.RenderMarkdown("Hello, world.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "<p>Hello, world.</p>") {
+		t.Errorf("expected paragraph tag, got: %s", out)
+	}
+}
+
+func TestRenderMarkdown_Table(t *testing.T) {
+	src := "| A | B |\n|---|---|\n| 1 | 2 |\n"
+	out, err := render.RenderMarkdown(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "<table>") {
+		t.Errorf("expected <table>, got: %s", out)
+	}
+}
+
+func TestRenderMarkdown_Strikethrough(t *testing.T) {
+	out, err := render.RenderMarkdown("~~deleted~~")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "<del>deleted</del>") {
+		t.Errorf("expected <del>, got: %s", out)
+	}
+}
+
+func TestRenderMarkdown_TaskList(t *testing.T) {
+	src := "- [ ] todo\n- [x] done\n"
+	out, err := render.RenderMarkdown(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `type="checkbox"`) {
+		t.Errorf("expected checkbox input, got: %s", out)
+	}
+}
+
+func TestRenderMarkdown_StripScript(t *testing.T) {
+	out, err := render.RenderMarkdown("<script>alert('xss')</script>")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "<script>") {
+		t.Errorf("safe mode should strip <script>, got: %s", out)
+	}
+}
+
+func TestRenderMarkdownUnsafe_AllowsRawHTML(t *testing.T) {
+	out, err := render.RenderMarkdownUnsafe("<em>raw</em>")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "<em>raw</em>") {
+		t.Errorf("unsafe mode should pass raw HTML through, got: %s", out)
+	}
+}


### PR DESCRIPTION
Add internal/render/markdown.go implementing RenderMarkdown (safe, strips raw HTML) and RenderMarkdownUnsafe (allows raw HTML) using github.com/yuin/goldmark with GFM extensions. Add tests in tests/markdown_test.go covering paragraphs, tables, strikethrough, task lists, stripping of script tags in safe mode, and raw HTML passthrough in unsafe mode. Also add the goldmark dependency to module files.