### PR TITLE
Add follow model and personalized home feed

### DIFF
--- a/internal/handler/home.go
+++ b/internal/handler/home.go
@@ -10,6 +10,8 @@ import (
 	"github.com/claude/blog/templates"
 )
 
+const homePageSize = 10
+
 func Home(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cats, err := model.AllCategories(db)
@@ -18,10 +20,58 @@ func Home(db *sql.DB) http.HandlerFunc {
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
+
 		theme := "dark"
-		if u := model.UserFromContext(r.Context()); u != nil && u.Theme != "" {
+		u := model.UserFromContext(r.Context())
+		if u != nil && u.Theme != "" {
 			theme = u.Theme
 		}
-		render.Component(w, r, templates.Home(cats, theme))
+
+		d := templates.HomeData{
+			Page:       1,
+			TotalPages: 1,
+			IsLoggedIn: u != nil,
+		}
+
+		if u != nil {
+			curators, err := model.FollowedCurators(db, u.ID)
+			if err != nil {
+				log.Printf("Home: followed curators: %v", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			d.HasFollows = len(curators) > 0
+		}
+
+		if d.HasFollows {
+			page := parsePage(r)
+			posts, total, err := model.PostsByFollowedCurators(db, u.ID, page, homePageSize)
+			if err != nil {
+				log.Printf("Home: PostsByFollowedCurators: %v", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			totalPages := (total + homePageSize - 1) / homePageSize
+			if totalPages == 0 {
+				totalPages = 1
+			}
+			d.Posts = posts
+			d.Page = page
+			d.TotalPages = totalPages
+		} else {
+			posts, err := model.RecentPosts(db, 20)
+			if err != nil {
+				log.Printf("Home: RecentPosts: %v", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			d.Posts = posts
+		}
+
+		if r.Header.Get("HX-Request") == "true" {
+			render.Component(w, r, templates.HomeInner(d))
+			return
+		}
+		render.Component(w, r, templates.Home(cats, theme, d))
 	}
 }

--- a/internal/model/follow.go
+++ b/internal/model/follow.go
@@ -1,0 +1,80 @@
+package model
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// Follow creates a follow relationship from followerID to curatorID.
+// Does nothing if the relationship already exists.
+func Follow(db *sql.DB, followerID, curatorID int64) error {
+	_, err := db.Exec(`
+		INSERT OR IGNORE INTO follows (follower_id, curator_id)
+		VALUES (?, ?)`, followerID, curatorID)
+	if err != nil {
+		return fmt.Errorf("Follow: %w", err)
+	}
+	return nil
+}
+
+// Unfollow removes the follow relationship from followerID to curatorID.
+func Unfollow(db *sql.DB, followerID, curatorID int64) error {
+	_, err := db.Exec(`
+		DELETE FROM follows WHERE follower_id = ? AND curator_id = ?`,
+		followerID, curatorID)
+	if err != nil {
+		return fmt.Errorf("Unfollow: %w", err)
+	}
+	return nil
+}
+
+// IsFollowing returns true if followerID follows curatorID.
+func IsFollowing(db *sql.DB, followerID, curatorID int64) (bool, error) {
+	var count int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM follows WHERE follower_id = ? AND curator_id = ?`,
+		followerID, curatorID).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("IsFollowing: %w", err)
+	}
+	return count > 0, nil
+}
+
+// FollowedCurators returns the users that followerID follows, most recently followed first.
+func FollowedCurators(db *sql.DB, followerID int64) ([]User, error) {
+	rows, err := db.Query(`
+		SELECT u.id, u.username, u.email, u.password_hash, u.role, u.bio,
+		       u.theme, u.email_notify_posts, u.email_notify_replies,
+		       u.is_banned, u.verified_at, u.last_active_at, u.created_at
+		FROM users u
+		JOIN follows f ON f.curator_id = u.id
+		WHERE f.follower_id = ?
+		ORDER BY f.created_at DESC`, followerID)
+	if err != nil {
+		return nil, fmt.Errorf("FollowedCurators: %w", err)
+	}
+	defer rows.Close()
+
+	var users []User
+	for rows.Next() {
+		var u User
+		var verifiedAt sql.NullTime
+		var notifyPosts, notifyReplies, isBanned int
+		if err := rows.Scan(
+			&u.ID, &u.Username, &u.Email, &u.PasswordHash, &u.Role,
+			&u.Bio, &u.Theme,
+			&notifyPosts, &notifyReplies, &isBanned,
+			&verifiedAt, &u.LastActiveAt, &u.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("FollowedCurators scan: %w", err)
+		}
+		u.EmailNotifyPosts = notifyPosts == 1
+		u.EmailNotifyReplies = notifyReplies == 1
+		u.IsBanned = isBanned == 1
+		if verifiedAt.Valid {
+			u.VerifiedAt = &verifiedAt.Time
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
+}

--- a/internal/model/post.go
+++ b/internal/model/post.go
@@ -253,6 +253,37 @@ func PostsByGroup(db *sql.DB, groupName string, page, pageSize int) ([]Post, int
 	return posts, total, nil
 }
 
+// PostsByFollowedCurators returns published, non-deleted posts by curators that followerID follows,
+// newest first. page is 1-based. Returns the posts and the total count.
+func PostsByFollowedCurators(db *sql.DB, followerID int64, page, pageSize int) ([]Post, int, error) {
+	var total int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM posts p
+		JOIN follows f ON f.curator_id = p.author_id
+		WHERE f.follower_id = ? AND p.status = 'published' AND p.is_deleted = 0`, followerID,
+	).Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("PostsByFollowedCurators count: %w", err)
+	}
+
+	offset := (page - 1) * pageSize
+	rows, err := db.Query(postSelect+`
+		JOIN follows f ON f.curator_id = p.author_id
+		WHERE f.follower_id = ? AND p.status = 'published' AND p.is_deleted = 0
+		ORDER BY p.published_at DESC
+		LIMIT ? OFFSET ?`, followerID, pageSize, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("PostsByFollowedCurators: %w", err)
+	}
+	defer rows.Close()
+
+	posts, err := scanPosts(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return posts, total, nil
+}
+
 // RecentPosts returns the most recently published, non-deleted posts across all categories.
 func RecentPosts(db *sql.DB, limit int) ([]Post, error) {
 	rows, err := db.Query(postSelect+`

--- a/templates/home.templ
+++ b/templates/home.templ
@@ -1,9 +1,48 @@
 package templates
 
-import "github.com/claude/blog/internal/model"
+import (
+	"github.com/claude/blog/internal/model"
+	"github.com/claude/blog/templates/components"
+)
 
-templ Home(cats []model.Category, theme string) {
+type HomeData struct {
+	Posts      []model.Post
+	Page       int
+	TotalPages int
+	HasFollows bool
+	IsLoggedIn bool
+}
+
+templ HomeInner(d HomeData) {
+	if len(d.Posts) == 0 {
+		<p class="post-list-empty">No posts yet.</p>
+	}
+	for _, p := range d.Posts {
+		@components.PostCard(p)
+	}
+	@components.Pagination(components.PaginationData{
+		CurrentPage: d.Page,
+		TotalPages:  d.TotalPages,
+		BaseURL:     "/",
+	})
+}
+
+templ Home(cats []model.Category, theme string, d HomeData) {
 	@Layout("Home", cats, "/", theme) {
-		<h1>Welcome to Atlas</h1>
+		<div class="post-list-header">
+			<h1>
+				if d.IsLoggedIn && d.HasFollows {
+					Your Feed
+				} else {
+					Recent Posts
+				}
+			</h1>
+			if d.IsLoggedIn && !d.HasFollows {
+				<p class="feed-hint">Follow curators to personalize your feed.</p>
+			}
+		</div>
+		<div id="post-list">
+			@HomeInner(d)
+		</div>
 	}
 }

--- a/templates/home_templ.go
+++ b/templates/home_templ.go
@@ -8,9 +8,20 @@ package templates
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import "github.com/claude/blog/internal/model"
+import (
+	"github.com/claude/blog/internal/model"
+	"github.com/claude/blog/templates/components"
+)
 
-func Home(cats []model.Category, theme string) templ.Component {
+type HomeData struct {
+	Posts      []model.Post
+	Page       int
+	TotalPages int
+	HasFollows bool
+	IsLoggedIn bool
+}
+
+func HomeInner(d HomeData) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -31,7 +42,52 @@ func Home(cats []model.Category, theme string) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var2 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		if len(d.Posts) == 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<p class=\"post-list-empty\">No posts yet.</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		for _, p := range d.Posts {
+			templ_7745c5c3_Err = components.PostCard(p).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = components.Pagination(components.PaginationData{
+			CurrentPage: d.Page,
+			TotalPages:  d.TotalPages,
+			BaseURL:     "/",
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func Home(cats []model.Category, theme string, d HomeData) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var2 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var2 == nil {
+			templ_7745c5c3_Var2 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var3 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -43,13 +99,46 @@ func Home(cats []model.Category, theme string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h1>Welcome to Atlas</h1>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"post-list-header\"><h1>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if d.IsLoggedIn && d.HasFollows {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "Your Feed")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "Recent Posts")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</h1>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if d.IsLoggedIn && !d.HasFollows {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<p class=\"feed-hint\">Follow curators to personalize your feed.</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div><div id=\"post-list\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = HomeInner(d).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = Layout("Home", cats, "/", theme).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Layout("Home", cats, "/", theme).Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/tests/follow_test.go
+++ b/tests/follow_test.go
@@ -1,0 +1,240 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/claude/blog/internal/model"
+)
+
+// --- Follow model tests ---
+
+func TestFollow_CreateAndCheck(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower1")
+	curator := makeUser(t, db, "curator1")
+
+	if err := model.Follow(db, follower.ID, curator.ID); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+
+	ok, err := model.IsFollowing(db, follower.ID, curator.ID)
+	if err != nil {
+		t.Fatalf("IsFollowing: %v", err)
+	}
+	if !ok {
+		t.Error("expected IsFollowing=true after Follow")
+	}
+}
+
+func TestFollow_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower2")
+	curator := makeUser(t, db, "curator2")
+
+	if err := model.Follow(db, follower.ID, curator.ID); err != nil {
+		t.Fatalf("first Follow: %v", err)
+	}
+	if err := model.Follow(db, follower.ID, curator.ID); err != nil {
+		t.Fatalf("second Follow (should be idempotent): %v", err)
+	}
+}
+
+func TestUnfollow(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower3")
+	curator := makeUser(t, db, "curator3")
+
+	if err := model.Follow(db, follower.ID, curator.ID); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	if err := model.Unfollow(db, follower.ID, curator.ID); err != nil {
+		t.Fatalf("Unfollow: %v", err)
+	}
+
+	ok, err := model.IsFollowing(db, follower.ID, curator.ID)
+	if err != nil {
+		t.Fatalf("IsFollowing: %v", err)
+	}
+	if ok {
+		t.Error("expected IsFollowing=false after Unfollow")
+	}
+}
+
+func TestUnfollow_NotFollowing(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower4")
+	curator := makeUser(t, db, "curator4")
+
+	// Unfollow someone we never followed — should not error
+	if err := model.Unfollow(db, follower.ID, curator.ID); err != nil {
+		t.Fatalf("Unfollow non-existent: %v", err)
+	}
+}
+
+func TestIsFollowing_False(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower5")
+	curator := makeUser(t, db, "curator5")
+
+	ok, err := model.IsFollowing(db, follower.ID, curator.ID)
+	if err != nil {
+		t.Fatalf("IsFollowing: %v", err)
+	}
+	if ok {
+		t.Error("expected IsFollowing=false when no follow exists")
+	}
+}
+
+func TestFollowedCurators_Empty(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower6")
+
+	curators, err := model.FollowedCurators(db, follower.ID)
+	if err != nil {
+		t.Fatalf("FollowedCurators: %v", err)
+	}
+	if len(curators) != 0 {
+		t.Errorf("expected 0 curators, got %d", len(curators))
+	}
+}
+
+func TestFollowedCurators_ReturnsList(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower7")
+	c1 := makeUser(t, db, "curator7a")
+	c2 := makeUser(t, db, "curator7b")
+
+	if err := model.Follow(db, follower.ID, c1.ID); err != nil {
+		t.Fatalf("Follow c1: %v", err)
+	}
+	if err := model.Follow(db, follower.ID, c2.ID); err != nil {
+		t.Fatalf("Follow c2: %v", err)
+	}
+
+	curators, err := model.FollowedCurators(db, follower.ID)
+	if err != nil {
+		t.Fatalf("FollowedCurators: %v", err)
+	}
+	if len(curators) != 2 {
+		t.Errorf("expected 2 curators, got %d", len(curators))
+	}
+}
+
+func TestFollowedCurators_OnlyOwnFollows(t *testing.T) {
+	db := openTestDB(t)
+	f1 := makeUser(t, db, "follower8a")
+	f2 := makeUser(t, db, "follower8b")
+	curator := makeUser(t, db, "curator8")
+
+	if err := model.Follow(db, f1.ID, curator.ID); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+
+	curators, err := model.FollowedCurators(db, f2.ID)
+	if err != nil {
+		t.Fatalf("FollowedCurators: %v", err)
+	}
+	if len(curators) != 0 {
+		t.Errorf("f2 should have 0 followed curators, got %d", len(curators))
+	}
+}
+
+// --- PostsByFollowedCurators model tests ---
+
+func TestPostsByFollowedCurators_Empty(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower9")
+
+	posts, total, err := model.PostsByFollowedCurators(db, follower.ID, 1, 10)
+	if err != nil {
+		t.Fatalf("PostsByFollowedCurators: %v", err)
+	}
+	if total != 0 || len(posts) != 0 {
+		t.Errorf("expected 0 posts, got total=%d len=%d", total, len(posts))
+	}
+}
+
+func TestPostsByFollowedCurators_ReturnsFollowedPosts(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower10")
+	curator := makeUser(t, db, "curator10")
+	other := makeUser(t, db, "other10")
+	catID := blogCatID(t, db)
+
+	if err := model.Follow(db, follower.ID, curator.ID); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	makePost(t, db, catID, curator.ID, "curator-post", "published")
+	makePost(t, db, catID, other.ID, "other-post", "published")
+
+	posts, total, err := model.PostsByFollowedCurators(db, follower.ID, 1, 10)
+	if err != nil {
+		t.Fatalf("PostsByFollowedCurators: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected total=1, got %d", total)
+	}
+	if len(posts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(posts))
+	}
+	if posts[0].Slug != "curator-post" {
+		t.Errorf("expected curator-post, got %q", posts[0].Slug)
+	}
+}
+
+func TestPostsByFollowedCurators_ExcludesDrafts(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower11")
+	curator := makeUser(t, db, "curator11")
+	catID := blogCatID(t, db)
+
+	if err := model.Follow(db, follower.ID, curator.ID); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	makePost(t, db, catID, curator.ID, "draft-post", "draft")
+	makePost(t, db, catID, curator.ID, "pub-post", "published")
+
+	posts, total, err := model.PostsByFollowedCurators(db, follower.ID, 1, 10)
+	if err != nil {
+		t.Fatalf("PostsByFollowedCurators: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected total=1 (only published), got %d", total)
+	}
+	if len(posts) != 1 || posts[0].Slug != "pub-post" {
+		t.Errorf("expected only pub-post, got %+v", posts)
+	}
+}
+
+func TestPostsByFollowedCurators_Pagination(t *testing.T) {
+	db := openTestDB(t)
+	follower := makeUser(t, db, "follower12")
+	curator := makeUser(t, db, "curator12")
+	catID := blogCatID(t, db)
+
+	if err := model.Follow(db, follower.ID, curator.ID); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	for i := range 5 {
+		makePost(t, db, catID, curator.ID, "fp-post-"+string(rune('a'+i)), "published")
+	}
+
+	posts, total, err := model.PostsByFollowedCurators(db, follower.ID, 1, 3)
+	if err != nil {
+		t.Fatalf("page 1: %v", err)
+	}
+	if total != 5 {
+		t.Errorf("expected total=5, got %d", total)
+	}
+	if len(posts) != 3 {
+		t.Errorf("expected 3 on page 1, got %d", len(posts))
+	}
+
+	posts2, _, err := model.PostsByFollowedCurators(db, follower.ID, 2, 3)
+	if err != nil {
+		t.Fatalf("page 2: %v", err)
+	}
+	if len(posts2) != 2 {
+		t.Errorf("expected 2 on page 2, got %d", len(posts2))
+	}
+}

--- a/tests/home_handler_test.go
+++ b/tests/home_handler_test.go
@@ -1,0 +1,218 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/claude/blog/internal/handler"
+	"github.com/claude/blog/internal/model"
+)
+
+func TestHome_VisitorSeesRecentPosts(t *testing.T) {
+	db := openTestDB(t)
+	u := makeUser(t, db, "homeauthor1")
+	catID := blogCatID(t, db)
+	p := makePost(t, db, catID, u.ID, "visible-post", "published")
+
+	srv := httptest.NewServer(handler.NewRouter(db, "static"))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body := readBody(t, resp)
+	if !strings.Contains(body, p.Title) {
+		t.Errorf("visitor should see post title %q", p.Title)
+	}
+	if !strings.Contains(body, "Recent Posts") {
+		t.Error("visitor should see 'Recent Posts' heading")
+	}
+}
+
+func TestHome_VisitorDoesNotSeeFollowHint(t *testing.T) {
+	db := openTestDB(t)
+	srv := httptest.NewServer(handler.NewRouter(db, "static"))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	if strings.Contains(body, "Follow curators") {
+		t.Error("visitor should not see follow-curators hint")
+	}
+}
+
+func TestHome_VisitorDoesNotSeeDrafts(t *testing.T) {
+	db := openTestDB(t)
+	u := makeUser(t, db, "homeauthor2")
+	catID := blogCatID(t, db)
+	makePost(t, db, catID, u.ID, "draft-only", "draft")
+
+	srv := httptest.NewServer(handler.NewRouter(db, "static"))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	if strings.Contains(body, "draft-only") {
+		t.Error("visitor should not see draft posts")
+	}
+}
+
+func TestHome_LoggedInNoFollows_SeesAllPostsAndHint(t *testing.T) {
+	db := openTestDB(t)
+	author := makeUser(t, db, "homeauthor3")
+	loggedIn := makeUser(t, db, "homefollower3")
+	catID := blogCatID(t, db)
+	p := makePost(t, db, catID, author.ID, "all-posts-visible", "published")
+
+	// Create a session for loggedIn user
+	token, err := model.CreateSession(db, loggedIn.ID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	srv := httptest.NewServer(handler.NewRouter(db, "static"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: token})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body := readBody(t, resp)
+	if !strings.Contains(body, p.Title) {
+		t.Errorf("logged-in user with no follows should see all posts, missing %q", p.Title)
+	}
+	if !strings.Contains(body, "Follow curators") {
+		t.Error("user with no follows should see follow-curators hint")
+	}
+	if !strings.Contains(body, "Recent Posts") {
+		t.Error("user with no follows should see 'Recent Posts' heading")
+	}
+}
+
+func TestHome_LoggedInWithFollows_SeesOnlyFollowedPosts(t *testing.T) {
+	db := openTestDB(t)
+	curator := makeUser(t, db, "homecurator4")
+	other := makeUser(t, db, "homeother4")
+	loggedIn := makeUser(t, db, "homefollower4")
+	catID := blogCatID(t, db)
+
+	curatorPost := makePost(t, db, catID, curator.ID, "curator-post-4", "published")
+	otherPost := makePost(t, db, catID, other.ID, "other-post-4", "published")
+
+	if err := model.Follow(db, loggedIn.ID, curator.ID); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+
+	token, err := model.CreateSession(db, loggedIn.ID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	srv := httptest.NewServer(handler.NewRouter(db, "static"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: token})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body := readBody(t, resp)
+	// Check by slug (appears in the post card's href) since all posts share the same default title.
+	if !strings.Contains(body, curatorPost.Slug) {
+		t.Errorf("should see followed curator's post with slug %q", curatorPost.Slug)
+	}
+	if strings.Contains(body, otherPost.Slug) {
+		t.Errorf("should not see unfollowed author's post with slug %q", otherPost.Slug)
+	}
+	if !strings.Contains(body, "Your Feed") {
+		t.Error("user following curators should see 'Your Feed' heading")
+	}
+}
+
+func TestHome_LoggedInWithFollows_NoFollowHint(t *testing.T) {
+	db := openTestDB(t)
+	curator := makeUser(t, db, "homecurator5")
+	loggedIn := makeUser(t, db, "homefollower5")
+
+	if err := model.Follow(db, loggedIn.ID, curator.ID); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+
+	token, err := model.CreateSession(db, loggedIn.ID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	srv := httptest.NewServer(handler.NewRouter(db, "static"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: token})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	if strings.Contains(body, "Follow curators") {
+		t.Error("user already following curators should not see follow hint")
+	}
+}
+
+func TestHome_HTMX_ReturnsFragment(t *testing.T) {
+	db := openTestDB(t)
+	srv := httptest.NewServer(handler.NewRouter(db, "static"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
+	req.Header.Set("HX-Request", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body := readBody(t, resp)
+	if strings.Contains(body, "<html") {
+		t.Error("HTMX response should not contain <html> wrapper")
+	}
+}


### PR DESCRIPTION
Introduce follower functionality and feed support: add model/follow.go with Follow/Unfollow/IsFollowing/FollowedCurators helpers; add PostsByFollowedCurators in model/post.go. Update Home handler to show a personalized feed for logged-in users (with pagination, HTMX fragment support, and homePageSize constant) or recent posts for others. Update templates to introduce HomeData and HomeInner and render feed vs recent posts. Add comprehensive tests for follow model and home handler behavior.